### PR TITLE
Fix query with dot notation on nested objects

### DIFF
--- a/nefertari_sqla/documents.py
+++ b/nefertari_sqla/documents.py
@@ -147,7 +147,7 @@ class BaseMixin(object):
 
         for name, column in relationships.items():
             if name in cls._nested_relationships and not depth_reached:
-                column_type = {'type': 'nested'}
+                column_type = {'type': 'nested', 'include_in_parent': True}
                 submapping = column.mapper.class_.get_es_mapping(
                     _depth=_depth-1)
                 column_type.update(list(submapping.values())[0])

--- a/nefertari_sqla/tests/test_documents.py
+++ b/nefertari_sqla/tests/test_documents.py
@@ -125,6 +125,7 @@ class TestBaseMixin(object):
                     'name': {'type': 'string'},
                     'myself': {
                         'type': 'nested',
+                        'include_in_parent': True,
                         'properties': myself_props
                     }
                 }


### PR DESCRIPTION
To be able to query using the dot notation, we need to copy the object to the parent. This is done using the include_in_parent on the field mapping.

Closed previous PR to exclude unrelated commits from blaurent.